### PR TITLE
UnitTests for SqlAudioEntriesRepository

### DIFF
--- a/NPlaylist/NPlaylist.Authentication/AuthenticationDbContext.cs
+++ b/NPlaylist/NPlaylist.Authentication/AuthenticationDbContext.cs
@@ -1,25 +1,13 @@
 ﻿using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
 
 namespace NPlaylist.Authentication
 {
     public class AuthenticationDbContext : IdentityDbContext
     {
-        private readonly IConfiguration _config;
-
-        public AuthenticationDbContext(IConfiguration config, DbContextOptions<AuthenticationDbContext> options)
+        public AuthenticationDbContext(DbContextOptions<AuthenticationDbContext> options)
             : base(options)
         {
-            _config = config;
-        }
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder.UseSqlServer(_config.GetConnectionString("AuthenticationDbConnection"), options =>
-            {
-                options.MigrationsHistoryTable("__UsersMigrationsHistory", "Authentication");
-            });
         }
     }
 }

--- a/NPlaylist/NPlaylist.Persistence/ApplicationDbContext.cs
+++ b/NPlaylist/NPlaylist.Persistence/ApplicationDbContext.cs
@@ -1,28 +1,15 @@
 ﻿using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
 using NPlaylist.Persistence.DbModels;
 
 namespace NPlaylist.Persistence
 {
     public class ApplicationDbContext : DbContext
     {
-        private readonly IConfiguration _config;
-
-        public ApplicationDbContext(IConfiguration config, DbContextOptions<ApplicationDbContext> options)
-            : base(options)
+        public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : base(options)
         {
-            _config = config ?? throw new System.ArgumentNullException(nameof(config));
         }
 
-        public DbSet<Audio> AudioEntries { get; set; }
-        public DbSet<AudioMeta> AudioMetaEntries { get; set; }
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder.UseSqlServer(_config.GetConnectionString("ApplicationDbConnection"), options =>
-            {
-                options.MigrationsHistoryTable("__UsersMigrationsHistory", "Application");
-            });
-        }
+        public virtual DbSet<Audio> AudioEntries { get; set; }
+        public virtual DbSet<AudioMeta> AudioMetaEntries { get; set; }
     }
 }

--- a/NPlaylist/NPlaylist.Persistence/AudioEntries/SqlAudioEntriesRepository.cs
+++ b/NPlaylist/NPlaylist.Persistence/AudioEntries/SqlAudioEntriesRepository.cs
@@ -4,8 +4,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
-using NPlaylist.Persistence;
-using NPlaylist.Persistence.AudioEntries;
 using NPlaylist.Persistence.CrudRepository;
 using NPlaylist.Persistence.DbModels;
 

--- a/NPlaylist/NPlaylist.Persistence/CrudRepository/SqlCrudRepository.cs
+++ b/NPlaylist/NPlaylist.Persistence/CrudRepository/SqlCrudRepository.cs
@@ -1,6 +1,4 @@
-﻿using System;
 ﻿using Microsoft.EntityFrameworkCore;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/NPlaylist/NPlaylist/NPlaylist.csproj
+++ b/NPlaylist/NPlaylist/NPlaylist.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.1" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.9" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NPlaylist/NPlaylist/Startup.cs
+++ b/NPlaylist/NPlaylist/Startup.cs
@@ -20,6 +20,7 @@ using NPlaylist.Persistence.AudioEntries;
 using NPlaylist.Services.AudioService;
 using NPlaylist.Authorization;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.EntityFrameworkCore;
 
 namespace NPlaylist
 {
@@ -107,8 +108,21 @@ namespace NPlaylist
 
         private void ConfigureDbContexts(IServiceCollection services)
         {
-            services.AddDbContext<ApplicationDbContext>();
-            services.AddDbContext<AuthenticationDbContext>();
+            services.AddDbContext<ApplicationDbContext>(optionsBuilder =>
+            {
+                optionsBuilder.UseSqlServer(Configuration.GetConnectionString("ApplicationDbConnection"), options =>
+                {
+                    options.MigrationsHistoryTable("__UsersMigrationsHistory", "Application");
+                });
+            });
+
+            services.AddDbContext<AuthenticationDbContext>(optionsBuilder =>
+            {
+                optionsBuilder.UseSqlServer(Configuration.GetConnectionString("AuthenticationDbConnection"), options =>
+                {
+                    options.MigrationsHistoryTable("__UsersMigrationsHistory", "Authentication");
+                });
+            });
             services.AddDefaultIdentity<IdentityUser>()
                 .AddEntityFrameworkStores<AuthenticationDbContext>();
         }

--- a/NPlaylist/Tests/NPlaylist.Persistance.Tests/AudioEntries/SqlAudioEntriesRepositoryTests.cs
+++ b/NPlaylist/Tests/NPlaylist.Persistance.Tests/AudioEntries/SqlAudioEntriesRepositoryTests.cs
@@ -1,0 +1,83 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using EntityFrameworkCoreMock.NSubstitute;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NPlaylist.Persistence.AudioEntries;
+using NPlaylist.Persistence.Tests.EntityBuilders;
+using Xunit;
+
+namespace NPlaylist.Persistence.Tests.AudioEntries
+{
+    public class SqlAudioEntriesRepositoryTests
+    {
+        private DbContextOptions<ApplicationDbContext> DummyDbOptions =>
+            new DbContextOptionsBuilder<ApplicationDbContext>().Options;
+
+        [Fact]
+        public async Task EntryExistsAsync_ForNonexistentElement_ReturnsFalse()
+        {
+            var audio = new AudioBuilder().WithId(GuidFactory.MakeFromInt(0)).Build();
+
+            var dbContextMock = new DbContextMock<ApplicationDbContext>(DummyDbOptions);
+            var audioEntriesDbSetMock = dbContextMock.CreateDbSetMock(x => x.AudioEntries, new[] { audio });
+
+            var sut = new SqlAudioEntriesRepository(dbContextMock.Object);
+
+            var actual = await sut.EntryExistsAsync(GuidFactory.MakeFromInt(1), CancellationToken.None);
+            actual.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task EntryExistsAsync_ForExistingElement_ReturnsTrue()
+        {
+            var audio = new AudioBuilder().Build();
+
+            var dbContextMock = new DbContextMock<ApplicationDbContext>(DummyDbOptions);
+            var audioEntriesDbSetMock = dbContextMock.CreateDbSetMock(x => x.AudioEntries, new[] { audio });
+
+            var sut = new SqlAudioEntriesRepository(dbContextMock.Object);
+
+            var actual = await sut.EntryExistsAsync(audio.AudioId, CancellationToken.None);
+            actual.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task CountAsync_ForMultipleEntries_CountAsExpected()
+        {
+            var audios = new[]
+            {
+                new AudioBuilder().WithId(GuidFactory.MakeFromInt(0)).Build(),
+                new AudioBuilder().WithId(GuidFactory.MakeFromInt(1)).Build(),
+            };
+
+            var dbContextMock = new DbContextMock<ApplicationDbContext>(DummyDbOptions);
+            var audioEntriesDbSetMock = dbContextMock.CreateDbSetMock(x => x.AudioEntries, audios);
+
+            var sut = new SqlAudioEntriesRepository(dbContextMock.Object);
+
+            var actual = await sut.CountAsync(CancellationToken.None);
+            actual.Should().Be(2);
+        }
+
+        [Fact]
+        public async Task GetRangeAsync_ReturnsExpectedNbOfElemnets()
+        {
+            var audios = new[]
+            {
+                new AudioBuilder().WithId(GuidFactory.MakeFromInt(0)).Build(),
+                new AudioBuilder().WithId(GuidFactory.MakeFromInt(1)).Build(),
+                new AudioBuilder().WithId(GuidFactory.MakeFromInt(2)).Build(),
+                new AudioBuilder().WithId(GuidFactory.MakeFromInt(3)).Build(),
+            };
+
+            var dbContextMock = new DbContextMock<ApplicationDbContext>(DummyDbOptions);
+            var audioEntriesDbSetMock = dbContextMock.CreateDbSetMock(x => x.AudioEntries, audios);
+
+            var sut = new SqlAudioEntriesRepository(dbContextMock.Object);
+
+            var actual = await sut.GetRangeAsync(1, 2, CancellationToken.None);
+            actual.Should().HaveCount(2);
+        }
+    }
+}

--- a/NPlaylist/Tests/NPlaylist.Persistance.Tests/CrudRepository/SqlCrudRepositoryTests.cs
+++ b/NPlaylist/Tests/NPlaylist.Persistance.Tests/CrudRepository/SqlCrudRepositoryTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace NPlaylist.Persistence.Tests.CrudRepository
 {
+    [Trait("Category", "Integration")]
     public class SqlCrudRepositoryTests
     {
         [Fact]

--- a/NPlaylist/Tests/NPlaylist.Persistance.Tests/EntityBuilders/AudioBuilder.cs
+++ b/NPlaylist/Tests/NPlaylist.Persistance.Tests/EntityBuilders/AudioBuilder.cs
@@ -6,10 +6,11 @@ namespace NPlaylist.Persistence.Tests.EntityBuilders
     public class AudioBuilder
     {
         private Guid _audioId;
+        private AudioMeta _meta;
 
         public AudioBuilder()
         {
-            _audioId = new Guid("00000000-0000-0000-0000-000000000001");
+            _audioId = GuidFactory.MakeFromInt(42);
         }
 
         public Audio Build()
@@ -17,12 +18,19 @@ namespace NPlaylist.Persistence.Tests.EntityBuilders
             return new Audio
             {
                 AudioId = _audioId,
+                Meta = _meta
             };
         }
 
         public AudioBuilder WithId(Guid audioId)
         {
             _audioId = audioId;
+            return this;
+        }
+
+        public AudioBuilder WithMeta(AudioMeta audioMeta)
+        {
+            _meta = audioMeta;
             return this;
         }
     }

--- a/NPlaylist/Tests/NPlaylist.Persistance.Tests/EntityBuilders/AudioMetaBuilder.cs
+++ b/NPlaylist/Tests/NPlaylist.Persistance.Tests/EntityBuilders/AudioMetaBuilder.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using NPlaylist.Persistence.DbModels;
+
+namespace NPlaylist.Persistence.Tests.EntityBuilders
+{
+    public class AudioMetaBuilder
+    {
+        private Guid _audioMetaId = new Guid();
+        private string _title = "Foo Title";
+        private string _author = "Foo Author";
+        private string _album = "Foo Album";
+
+        public AudioMeta Build()
+        {
+            return new AudioMeta
+            {
+                AudioMetaId = _audioMetaId,
+                Title = _title,
+                Author = _author,
+                Album = _album
+            };
+        }
+    }
+}

--- a/NPlaylist/Tests/NPlaylist.Persistance.Tests/GuidFactory.cs
+++ b/NPlaylist/Tests/NPlaylist.Persistance.Tests/GuidFactory.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace NPlaylist.Persistence.Tests
+{
+    public static class GuidFactory
+    {
+        public static Guid MakeFromInt(int value)
+        {
+            var bytes = new byte[16];
+            BitConverter.GetBytes(value).CopyTo(bytes, 0);
+            return new Guid(bytes);
+        }
+    }
+}

--- a/NPlaylist/Tests/NPlaylist.Persistance.Tests/NPlaylist.Persistence.Tests.csproj
+++ b/NPlaylist/Tests/NPlaylist.Persistance.Tests/NPlaylist.Persistence.Tests.csproj
@@ -13,12 +13,14 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.2.4" />
     <PackageReference Include="NSubstitute" Version="4.0.0" />
     <PackageReference Include="FluentAssertions" Version="5.6.0" />
+    <PackageReference Include="EntityFrameworkCoreMock.NSubstitute" Version="1.0.0.25" />
   </ItemGroup>
 
   <ItemGroup>
     <Folder Include="CrudRepository\" />
     <Folder Include="CrudRepository\Stubs\" />
     <Folder Include="EntityBuilders\" />
+    <Folder Include="AudioEntries\" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\NPlaylist.Persistence\NPlaylist.Persistence.csproj" />


### PR DESCRIPTION
1. [Tested](https://github.com/internship2019/nplaylist-website/blob/tests/persistence_tests/NPlaylist/Tests/NPlaylist.Persistance.Tests/AudioEntries/SqlAudioEntriesRepositoryTests.cs) the `SqlAudioEntriesRepository` using a nugget package to mock the app db context
2. Moved the Configuration of `ApplicationDbContext` and `AuthenticationDbContext` to [`Startup.cs`](https://github.com/internship2019/nplaylist-website/blob/tests/persistence_tests/NPlaylist/NPlaylist/Startup.cs#L113)
3. [Marked](https://github.com/internship2019/nplaylist-website/blob/tests/persistence_tests/NPlaylist/Tests/NPlaylist.Persistance.Tests/CrudRepository/SqlCrudRepositoryTests.cs#L9) `SqlCrudRepositoryTests` as Integration tests since it uses an InMemory Db to test the repo

Auxiliary:
1. [`GuidFactory.MakeFromInt(int)`](https://github.com/internship2019/nplaylist-website/blob/tests/persistence_tests/NPlaylist/Tests/NPlaylist.Persistance.Tests/GuidFactory.cs) - test utility to easily generate Guids